### PR TITLE
Issue #236 by cableman: Ensured that groups are add to node queue on creation

### DIFF
--- a/ding_groups.module
+++ b/ding_groups.module
@@ -53,6 +53,16 @@ function ding_groups_og_context_handler() {
 function ding_groups_node_insert($node) {
   if ($node->type == 'ding_group') {
     ding_groups_node_update($node);
+
+    // Get groups listing queue.
+    $queue = nodequeue_load_queue_by_name('ding_groups_listning');
+
+    // Load sub-queue.
+    $sub_queue = nodequeue_load_subqueues_by_queue($queue->qid);
+    $sub_queue = reset($sub_queue);
+
+    // Add the node to the queue.
+    nodequeue_subqueue_add($queue, $sub_queue, $node->nid);
   }
 }
 


### PR DESCRIPTION
Added an add to node queue the groups page so that it can be rearrange into the right position in the list by editors. This is the same solution as  for libraries.